### PR TITLE
Remove defunct codegen

### DIFF
--- a/frontend/assets_generate.go
+++ b/frontend/assets_generate.go
@@ -3,14 +3,8 @@
 package main
 
 import (
-	"fmt"
-	"html/template"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/shurcooL/vfsgen"
 )
@@ -26,53 +20,4 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	err = generateAbsolutePaths("static")
-	if err != nil {
-		panic(err)
-	}
-
-}
-
-func generateAbsolutePaths(dir string) error {
-
-	type entries struct {
-		Entries []string
-	}
-	var paths entries
-	// collect paths
-	visit := func(path string, f os.FileInfo, err error) error {
-		if !f.IsDir() {
-			trimmed := strings.TrimPrefix(path, "static/")
-			fmt.Println("adding path", trimmed)
-			paths.Entries = append(paths.Entries, trimmed)
-		}
-		return nil
-	}
-	err := filepath.Walk(dir, visit)
-	if err != nil {
-		return err
-	}
-
-	var t = template.Must(template.New("entries").Funcs(template.FuncMap{
-		"quote": strconv.Quote,
-	}).Parse(`package bundle
-
-var Entries = []string{
-		{{range .Entries}}
-	"{{ .}}",
-		{{end}}
-	}
-	`))
-
-	f, err := os.Create("bundle/entries.go")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	err = t.ExecuteTemplate(f, "entries", paths)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,7 +8,7 @@ import './App.css';
 
 
 
-class Button extends React.Component {
+class AddBackendButton extends React.Component {
   clicker() {
     // we connect to the Web UI port
     // CORS PROBS...
@@ -42,7 +42,7 @@ class App extends React.Component {
         <header>co-chair</header>
         <nav>
           <div><a href="/login">login!!!!</a></div>
-          <Button></Button>
+          <AddBackendButton />
           <div>Thing</div>
           <div>Thing</div>
         </nav>


### PR DESCRIPTION
We used to add precise static routes for each frontend build, but now
we just capture all of them in a regular expression, so we no longer
need to create a data structure to hold them at compile time.